### PR TITLE
Create TypeScript definition for package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+class List <T extends List.Item> {
+  static of<T extends List.Item>(...items: T[]): List<T>
+  static from<T extends List.Item>(items: T[]): List<T>
+
+  head: T | null
+  tail: T | null
+
+  constructor(...items: T[])
+  toArray(): T[]
+  prepend<T>(item: T): T
+  append<T>(item: T): T
+}
+
+namespace List {
+  export class Item {
+    prev: Item
+    next: Item
+    list: List
+
+    detach(): this
+    prepend<T extends Item>(item: T): T
+    append<T extends Item>(item: T): T
+  }
+}
+
+export = List


### PR DESCRIPTION
Closes https://github.com/wooorm/linked-list/issues/7. I used generics since this library expects `Item` to be subclasses and I expect that the correct type is expected to be returned from each property.