### PR TITLE
Fix types for v3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class List<T extends List.Item> implements Iterable<T> {
+export class List<T extends List.Item> implements Iterable<T> {
   static of<T extends List.Item>(...items: T[]): List<T>
   static from<T extends List.Item>(items: Iterable<T>): List<T>
 
@@ -13,16 +13,12 @@ declare class List<T extends List.Item> implements Iterable<T> {
   [Symbol.iterator](): Iterator<T>
 }
 
-declare namespace List {
-  export class Item {
-    prev: this
-    next: this
-    list: List<this>
+export class Item {
+  prev: this
+  next: this
+  list: List<this>
 
-    detach(): this
-    prepend<T extends this>(item: T): T
-    append<T extends this>(item: T): T
-  }
+  detach(): this
+  prepend<T extends this>(item: T): T
+  append<T extends this>(item: T): T
 }
-
-export = List


### PR DESCRIPTION
Both `List` and `Item` are named exports now.