### PR TITLE
Fix to prevent appending or prepending self

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.log
+.idea
 coverage/
 node_modules/
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -23,24 +23,26 @@ export class Item {
 
     if (!item || !item.append || !item.prepend || !item.detach) {
       throw new Error(
-        'An argument without append, prepend, or detach methods was given to `Item#prepend`.'
-      )
+        'An argument without append, prepend, or detach methods was given to `Item#prepend`.',
+      );
     }
 
     // If self is detached, return false.
     if (!list) {
-      return false
+      return false;
     }
+
+    // Prevent broken pointers
     if (this === item) {
       return false;
     }
 
     // Detach the prependee.
-    item.detach()
+    item.detach();
 
     // If self has a previous item...
     if (this.prev) {
-      item.prev = this.prev
+      item.prev = this.prev;
       this.prev.next = item
     }
 
@@ -73,23 +75,25 @@ export class Item {
 
     if (!item || !item.append || !item.prepend || !item.detach) {
       throw new Error(
-        'An argument without append, prepend, or detach methods was given to `Item#append`.'
-      )
+        'An argument without append, prepend, or detach methods was given to `Item#append`.',
+      );
     }
 
     if (!list) {
-      return false
+      return false;
     }
+
+    // Prevent broken pointers
     if (this === item) {
       return false;
     }
 
     // Detach the appendee.
-    item.detach()
+    item.detach();
 
     // If self has a next item…
     if (this.next) {
-      item.next = this.next
+      item.next = this.next;
       this.next.prev = item
     }
 

--- a/index.js
+++ b/index.js
@@ -23,26 +23,26 @@ export class Item {
 
     if (!item || !item.append || !item.prepend || !item.detach) {
       throw new Error(
-        'An argument without append, prepend, or detach methods was given to `Item#prepend`.',
-      );
+        'An argument without append, prepend, or detach methods was given to `Item#prepend`.'
+      )
     }
 
     // If self is detached, return false.
     if (!list) {
-      return false;
+      return false
     }
 
     // Prevent broken pointers
     if (this === item) {
-      return false;
+      return false
     }
 
     // Detach the prependee.
-    item.detach();
+    item.detach()
 
     // If self has a previous item...
     if (this.prev) {
-      item.prev = this.prev;
+      item.prev = this.prev
       this.prev.next = item
     }
 
@@ -75,25 +75,25 @@ export class Item {
 
     if (!item || !item.append || !item.prepend || !item.detach) {
       throw new Error(
-        'An argument without append, prepend, or detach methods was given to `Item#append`.',
-      );
+        'An argument without append, prepend, or detach methods was given to `Item#append`.'
+      )
     }
 
     if (!list) {
-      return false;
+      return false
     }
 
     // Prevent broken pointers
     if (this === item) {
-      return false;
+      return false
     }
 
     // Detach the appendee.
-    item.detach();
+    item.detach()
 
     // If self has a next item…
     if (this.next) {
-      item.next = this.next;
+      item.next = this.next
       this.next.prev = item
     }
 

--- a/index.js
+++ b/index.js
@@ -27,13 +27,8 @@ export class Item {
       )
     }
 
-    // If self is detached, return false.
-    if (!list) {
-      return false
-    }
-
-    // Prevent broken pointers
-    if (this === item) {
+    // If self is detached or prepending ourselves, return false.
+    if (!list || this === item) {
       return false
     }
 
@@ -79,12 +74,8 @@ export class Item {
       )
     }
 
-    if (!list) {
-      return false
-    }
-
-    // Prevent broken pointers
-    if (this === item) {
+    // If self is detached or appending ourselves, return false.
+    if (!list || this === item) {
       return false
     }
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ export class Item {
     if (!list) {
       return false
     }
+    if (this === item) {
+      return false;
+    }
 
     // Detach the prependee.
     item.detach()
@@ -76,6 +79,9 @@ export class Item {
 
     if (!list) {
       return false
+    }
+    if (this === item) {
+      return false;
     }
 
     // Detach the appendee.

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
-import test from 'tape'
-import {List, Item} from './index.js'
+import test from 'tape';
+import {Item, List} from './index.js';
 
-var own = {}.hasOwnProperty
+var own = {}.hasOwnProperty;
 
 test('List [List]', function (t) {
   t.test('@constructor', function (t) {
-    t.equal(typeof List.of, 'function', 'should have an `of` method')
-    t.equal(typeof List.from, 'function', 'should have a `from` method')
+    t.equal(typeof List.of, 'function', 'should have an `of` method');
+    t.equal(typeof List.from, 'function', 'should have a `from` method');
 
-    t.end()
-  })
+    t.end();
+  });
 
   t.test('of [List.of]', function (t) {
     class C extends List {}
@@ -432,23 +432,32 @@ test('Item [List.Item]', function (t) {
     }, 'should throw an error when an invalid item is given (1)')
 
     t.throws(function () {
-      item.prepend({})
-    }, 'should throw an error when an invalid item is given (2)')
+      item.prepend({});
+    }, 'should throw an error when an invalid item is given (2)');
 
-    item = new Item()
-    other = new Item()
-    list = new List()
-    list.append(item)
+    item = new Item();
+    other = new Item();
+    list = new List();
+    list.append(item);
+
+    t.equal(
+      item.prepend(item),
+      false,
+      'should return false when the item tries to prepend itself',
+    );
+
+    t.equal(item.prev, null, 'should do nothing if single `item` (1)');
+    t.equal(item.next, null, 'should do nothing if single `item` (2)');
 
     t.equal(
       item.prepend(other),
       other,
       'should return the given item when ' +
-        'the operated on instance is ' +
-        'attached'
-    )
+      'the operated on instance is ' +
+      'attached',
+    );
 
-    t.equal(list.size, 2, 'should update size after prepend on item')
+    t.equal(list.size, 2, 'should update size after prepend on item');
 
     item = new Item()
     other = new List(item)
@@ -530,23 +539,32 @@ test('Item [List.Item]', function (t) {
     }, 'should throw an error when an invalid item is given (1)')
 
     t.throws(function () {
-      item.append({})
-    }, 'should throw an error when an invalid item is given (2)')
+      item.append({});
+    }, 'should throw an error when an invalid item is given (2)');
 
-    item = new Item()
-    other = new Item()
-    list = new List()
-    list.append(item)
+    item = new Item();
+    other = new Item();
+    list = new List();
+    list.append(item);
+
+    t.equal(
+      item.append(item),
+      false,
+      'should return false when the item tries to append itself',
+    );
+
+    t.equal(item.prev, null, 'should do nothing if single `item` (1)');
+    t.equal(item.next, null, 'should do nothing if single `item` (2)');
 
     t.equal(
       item.append(other),
       other,
       'should return the given item when ' +
-        'the operated on instance is ' +
-        'attached'
-    )
+      'the operated on instance is ' +
+      'attached',
+    );
 
-    t.equal(list.size, 2, 'should update size after append on item')
+    t.equal(list.size, 2, 'should update size after append on item');
 
     item = new Item()
     other = new List(item)

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
-import test from 'tape';
-import {Item, List} from './index.js';
+import test from 'tape'
+import {List, Item} from './index.js'
 
-var own = {}.hasOwnProperty;
+var own = {}.hasOwnProperty
 
 test('List [List]', function (t) {
   t.test('@constructor', function (t) {
-    t.equal(typeof List.of, 'function', 'should have an `of` method');
-    t.equal(typeof List.from, 'function', 'should have a `from` method');
+    t.equal(typeof List.of, 'function', 'should have an `of` method')
+    t.equal(typeof List.from, 'function', 'should have a `from` method')
 
-    t.end();
-  });
+    t.end()
+  })
 
   t.test('of [List.of]', function (t) {
     class C extends List {}
@@ -432,32 +432,32 @@ test('Item [List.Item]', function (t) {
     }, 'should throw an error when an invalid item is given (1)')
 
     t.throws(function () {
-      item.prepend({});
-    }, 'should throw an error when an invalid item is given (2)');
+      item.prepend({})
+    }, 'should throw an error when an invalid item is given (2)')
 
-    item = new Item();
-    other = new Item();
-    list = new List();
-    list.append(item);
+    item = new Item()
+    other = new Item()
+    list = new List()
+    list.append(item)
 
     t.equal(
       item.prepend(item),
       false,
-      'should return false when the item tries to prepend itself',
-    );
+      'should return false when the item tries to prepend itself'
+    )
 
-    t.equal(item.prev, null, 'should do nothing if single `item` (1)');
-    t.equal(item.next, null, 'should do nothing if single `item` (2)');
+    t.equal(item.prev, null, 'should do nothing if single `item` (1)')
+    t.equal(item.next, null, 'should do nothing if single `item` (2)')
 
     t.equal(
       item.prepend(other),
       other,
       'should return the given item when ' +
-      'the operated on instance is ' +
-      'attached',
-    );
+        'the operated on instance is ' +
+        'attached'
+    )
 
-    t.equal(list.size, 2, 'should update size after prepend on item');
+    t.equal(list.size, 2, 'should update size after prepend on item')
 
     item = new Item()
     other = new List(item)
@@ -539,32 +539,32 @@ test('Item [List.Item]', function (t) {
     }, 'should throw an error when an invalid item is given (1)')
 
     t.throws(function () {
-      item.append({});
-    }, 'should throw an error when an invalid item is given (2)');
+      item.append({})
+    }, 'should throw an error when an invalid item is given (2)')
 
-    item = new Item();
-    other = new Item();
-    list = new List();
-    list.append(item);
+    item = new Item()
+    other = new Item()
+    list = new List()
+    list.append(item)
 
     t.equal(
       item.append(item),
       false,
-      'should return false when the item tries to append itself',
-    );
+      'should return false when the item tries to append itself'
+    )
 
-    t.equal(item.prev, null, 'should do nothing if single `item` (1)');
-    t.equal(item.next, null, 'should do nothing if single `item` (2)');
+    t.equal(item.prev, null, 'should do nothing if single `item` (1)')
+    t.equal(item.next, null, 'should do nothing if single `item` (2)')
 
     t.equal(
       item.append(other),
       other,
       'should return the given item when ' +
-      'the operated on instance is ' +
-      'attached',
-    );
+        'the operated on instance is ' +
+        'attached'
+    )
 
-    t.equal(list.size, 2, 'should update size after append on item');
+    t.equal(list.size, 2, 'should update size after append on item')
 
     item = new Item()
     other = new List(item)


### PR DESCRIPTION
If you somehow end up trying to append/prepend an item to itself, bad things happen. This PR blocks that.